### PR TITLE
Update form badges with pastel backgrounds and remove icons

### DIFF
--- a/app/forms/mK9qPA/form-styles.css
+++ b/app/forms/mK9qPA/form-styles.css
@@ -71,13 +71,19 @@
 }
 
 .form-badges md-assist-chip {
-  --md-assist-chip-label-text-color: var(--md-sys-color-on-surface-variant);
-  --md-assist-chip-outline-color: var(--md-sys-color-outline);
+  --md-assist-chip-outline-width: 0px;
 }
 
-/* Icônes dans les badges - même couleur que le texte */
-.form-badges md-assist-chip .material-symbols-outlined {
-  color: var(--md-sys-color-on-surface-variant);
+/* Badge Official - Fond bleu pastel */
+.form-badges md-assist-chip.badge-official {
+  --md-assist-chip-container-color: rgb(227, 242, 253);
+  --md-assist-chip-label-text-color: rgb(1, 87, 155);
+}
+
+/* Badge Open - Fond vert pastel */
+.form-badges md-assist-chip.badge-open {
+  --md-assist-chip-container-color: rgb(232, 245, 233);
+  --md-assist-chip-label-text-color: rgb(27, 94, 32);
 }
 
 /* === Typography === */

--- a/app/forms/mK9qPA/page.js
+++ b/app/forms/mK9qPA/page.js
@@ -80,12 +80,10 @@ export default function FormPage() {
           <div className="form-card">
             {/* Status Badges */}
             <div className="form-badges">
-              <md-assist-chip label={t.badgeOfficial}>
-                <span className="material-symbols-outlined" slot="icon">verified</span>
+              <md-assist-chip label={t.badgeOfficial} className="badge-official">
                 {t.badgeOfficial}
               </md-assist-chip>
-              <md-assist-chip label={t.badgeOpen}>
-                <span className="material-symbols-outlined" slot="icon">check_circle</span>
+              <md-assist-chip label={t.badgeOpen} className="badge-open">
                 {t.badgeOpen}
               </md-assist-chip>
             </div>


### PR DESCRIPTION
Badge improvements:
- Removed icons from Official and Open badges
- Added pastel blue background (rgb(227, 242, 253)) for Official badge
- Added pastel green background (rgb(232, 245, 233)) for Open badge
- Set matching text colors (dark blue and dark green)
- Removed outline border from badges (outline-width: 0px)

Clean and modern appearance following Material Design 3 principles.