### PR TITLE
Add blue theme, dark mode toggle, redirect page, and improve homepage…

### DIFF
--- a/app/forms/mK9qPA/form-styles.css
+++ b/app/forms/mK9qPA/form-styles.css
@@ -39,6 +39,16 @@
   object-fit: contain;
 }
 
+.form-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.form-theme-toggle {
+  --md-icon-button-icon-size: 24px;
+}
+
 /* === Main Content === */
 .form-main-content {
   flex: 1;

--- a/app/forms/mK9qPA/page.js
+++ b/app/forms/mK9qPA/page.js
@@ -12,7 +12,17 @@ import '@material/web/ripple/ripple.js';
 
 export default function FormPage() {
   const [isEnglish, setIsEnglish] = useState(true);
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const discordOAuthURL = "https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fmoddy.app%2Fforms%2FmK9qPA%2Fcallback&scope=identify+email+guilds";
+
+  // Initialize theme from localStorage
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initialDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
+    setIsDarkMode(initialDark);
+    document.documentElement.setAttribute('data-theme', initialDark ? 'dark' : 'light');
+  }, []);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -21,6 +31,14 @@ export default function FormPage() {
       console.error('OAuth Error:', error);
     }
   }, []);
+
+  const toggleTheme = () => {
+    const newTheme = !isDarkMode;
+    setIsDarkMode(newTheme);
+    const themeValue = newTheme ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', themeValue);
+    localStorage.setItem('theme', themeValue);
+  };
 
   const content = {
     en: {
@@ -62,15 +80,23 @@ export default function FormPage() {
             />
           </div>
 
-          <md-filled-tonal-button
-            className="form-language-btn"
-            onClick={() => setIsEnglish(!isEnglish)}
-          >
-            <span className="material-symbols-outlined" slot="icon">
-              language
-            </span>
-            {t.languageBtn}
-          </md-filled-tonal-button>
+          <div className="form-header-actions">
+            <md-icon-button onClick={toggleTheme} className="form-theme-toggle">
+              <span className="material-symbols-outlined">
+                {isDarkMode ? 'light_mode' : 'dark_mode'}
+              </span>
+            </md-icon-button>
+
+            <md-filled-tonal-button
+              className="form-language-btn"
+              onClick={() => setIsEnglish(!isEnglish)}
+            >
+              <span className="material-symbols-outlined" slot="icon">
+                language
+              </span>
+              {t.languageBtn}
+            </md-filled-tonal-button>
+          </div>
         </div>
       </header>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -61,12 +61,22 @@ body {
   object-fit: contain;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-toggle {
+  --md-icon-button-icon-size: 24px;
+}
+
 /* === Hero Section === */
 .hero-section {
   flex: 1;
   display: flex;
   align-items: center;
-  padding: 96px 16px 48px;
+  padding: 120px 24px 64px;
   background: var(--md-sys-color-background);
 }
 
@@ -81,81 +91,105 @@ body {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
-  max-width: 840px;
+  gap: 24px;
+  max-width: 900px;
 }
 
 /* === Status Badge === */
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: 10px;
+  padding: 10px 20px;
   background: var(--md-sys-color-primary-container);
   color: var(--md-sys-color-on-primary-container);
   border-radius: var(--md-sys-shape-corner-full);
 }
 
 .status-indicator {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   background: var(--md-sys-color-primary);
   border-radius: 50%;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .status-text {
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.8px;
 }
 
 /* === Hero Typography === */
 .hero-title {
   color: var(--md-sys-color-on-background);
-  margin-top: 8px;
+  margin-top: 0;
+  font-size: 64px !important;
+  line-height: 72px !important;
+  font-weight: 400;
+  letter-spacing: -0.5px;
 }
 
 .hero-subtitle {
   color: var(--md-sys-color-on-surface-variant);
-  margin-top: 4px;
+  margin-top: 0;
+  font-size: 32px !important;
+  line-height: 40px !important;
+  font-weight: 400;
 }
 
 .hero-description {
   color: var(--md-sys-color-on-surface-variant);
-  line-height: 1.5;
-  max-width: 600px;
+  line-height: 1.6;
+  max-width: 700px;
+  font-size: 18px !important;
+  line-height: 28px !important;
 }
 
 /* === Action Buttons === */
 .action-buttons {
   display: flex;
-  gap: 12px;
-  margin-top: 16px;
+  gap: 16px;
+  margin-top: 8px;
   flex-wrap: wrap;
 }
 
 /* === Features Grid === */
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
   width: 100%;
-  margin-top: 48px;
+  margin-top: 64px;
 }
 
 .feature-card {
   background: var(--md-sys-color-surface-container);
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
-  padding: 24px;
+  padding: 32px;
   text-align: left;
+  transition: box-shadow 200ms ease;
+}
+
+.feature-card:hover {
+  box-shadow: var(--md-sys-elevation-level2);
 }
 
 .feature-icon {
-  width: 48px;
-  height: 48px;
-  margin-bottom: 16px;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -165,27 +199,28 @@ body {
 }
 
 .feature-icon .material-symbols-outlined {
-  font-size: 24px;
+  font-size: 28px;
 }
 
 .feature-title {
   color: var(--md-sys-color-on-surface);
-  margin-bottom: 8px;
-  font-size: 16px;
+  margin-bottom: 12px;
+  font-size: 18px;
   font-weight: 500;
+  line-height: 24px;
 }
 
 .feature-description {
   color: var(--md-sys-color-on-surface-variant);
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.6;
 }
 
 /* === Footer === */
 .footer {
   background: var(--md-sys-color-surface);
   border-top: 1px solid var(--md-sys-color-outline-variant);
-  padding: 24px 16px;
+  padding: 32px 24px;
 }
 
 .footer-container {
@@ -196,8 +231,8 @@ body {
 
 .footer-text {
   color: var(--md-sys-color-on-surface-variant);
-  font-size: 14px;
-  line-height: 20px;
+  font-size: 15px;
+  line-height: 24px;
 }
 
 .footer-link {
@@ -221,21 +256,26 @@ body {
   }
 
   .hero-section {
-    padding: 80px 16px 32px;
+    padding: 96px 20px 48px;
+  }
+
+  .hero-content {
+    gap: 20px;
   }
 
   .hero-title {
-    font-size: 36px !important;
-    line-height: 40px !important;
+    font-size: 44px !important;
+    line-height: 52px !important;
   }
 
   .hero-subtitle {
-    font-size: 20px !important;
-    line-height: 28px !important;
+    font-size: 26px !important;
+    line-height: 34px !important;
   }
 
   .hero-description {
-    font-size: 14px !important;
+    font-size: 16px !important;
+    line-height: 26px !important;
   }
 
   .action-buttons {
@@ -250,23 +290,51 @@ body {
 
   .features-grid {
     grid-template-columns: 1fr;
-    margin-top: 32px;
+    margin-top: 48px;
+    gap: 20px;
+  }
+
+  .feature-card {
+    padding: 28px;
   }
 }
 
 @media (max-width: 480px) {
+  .hero-section {
+    padding: 88px 16px 40px;
+  }
+
+  .hero-content {
+    gap: 18px;
+  }
+
   .hero-title {
-    font-size: 28px !important;
-    line-height: 32px !important;
+    font-size: 36px !important;
+    line-height: 44px !important;
   }
 
   .hero-subtitle {
-    font-size: 18px !important;
+    font-size: 22px !important;
+    line-height: 30px !important;
+  }
+
+  .hero-description {
+    font-size: 15px !important;
     line-height: 24px !important;
   }
 
   .feature-card {
-    padding: 20px;
+    padding: 24px;
+  }
+
+  .feature-icon {
+    width: 48px;
+    height: 48px;
+    margin-bottom: 16px;
+  }
+
+  .feature-icon .material-symbols-outlined {
+    font-size: 24px;
   }
 }
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import '@material/web/button/filled-button.js';
 import '@material/web/button/outlined-button.js';
 import '@material/web/button/filled-tonal-button.js';
@@ -9,6 +9,24 @@ import '@material/web/ripple/ripple.js';
 
 export default function Home() {
   const [isEnglish, setIsEnglish] = useState(true);
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  // Initialize theme from localStorage
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initialDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
+    setIsDarkMode(initialDark);
+    document.documentElement.setAttribute('data-theme', initialDark ? 'dark' : 'light');
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = !isDarkMode;
+    setIsDarkMode(newTheme);
+    const themeValue = newTheme ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', themeValue);
+    localStorage.setItem('theme', themeValue);
+  };
 
   const content = {
     en: {
@@ -46,15 +64,23 @@ export default function Home() {
             />
           </div>
 
-          <md-filled-tonal-button
-            className="language-btn"
-            onClick={() => setIsEnglish(!isEnglish)}
-          >
-            <span className="material-symbols-outlined" slot="icon">
-              language
-            </span>
-            {t.languageBtn}
-          </md-filled-tonal-button>
+          <div className="header-actions">
+            <md-icon-button onClick={toggleTheme} className="theme-toggle">
+              <span className="material-symbols-outlined">
+                {isDarkMode ? 'light_mode' : 'dark_mode'}
+              </span>
+            </md-icon-button>
+
+            <md-filled-tonal-button
+              className="language-btn"
+              onClick={() => setIsEnglish(!isEnglish)}
+            >
+              <span className="material-symbols-outlined" slot="icon">
+                language
+              </span>
+              {t.languageBtn}
+            </md-filled-tonal-button>
+          </div>
         </div>
       </header>
 

--- a/app/redirect/page.js
+++ b/app/redirect/page.js
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import '@material/web/button/filled-button.js';
+import '@material/web/button/filled-tonal-button.js';
+import '@material/web/iconbutton/icon-button.js';
+import '@material/web/progress/linear-progress.js';
+import './redirect-styles.css';
+
+export default function RedirectPage() {
+  const [isEnglish, setIsEnglish] = useState(true);
+  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [countdown, setCountdown] = useState(3);
+  const [redirectUrl, setRedirectUrl] = useState('');
+
+  // Initialize theme from localStorage
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initialDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
+    setIsDarkMode(initialDark);
+    document.documentElement.setAttribute('data-theme', initialDark ? 'dark' : 'light');
+  }, []);
+
+  // Get redirect URL from query params
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const url = urlParams.get('url');
+    if (url) {
+      setRedirectUrl(decodeURIComponent(url));
+    }
+  }, []);
+
+  // Countdown and redirect
+  useEffect(() => {
+    if (!redirectUrl) return;
+
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          window.location.href = redirectUrl;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [redirectUrl]);
+
+  const toggleTheme = () => {
+    const newTheme = !isDarkMode;
+    setIsDarkMode(newTheme);
+    const themeValue = newTheme ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', themeValue);
+    localStorage.setItem('theme', themeValue);
+  };
+
+  const content = {
+    en: {
+      title: 'Redirecting...',
+      message: 'You will be redirected in',
+      seconds: 'seconds',
+      noUrl: 'No redirect URL provided',
+      goHome: 'Go to Home',
+      languageBtn: 'Français'
+    },
+    fr: {
+      title: 'Redirection...',
+      message: 'Vous serez redirigé dans',
+      seconds: 'secondes',
+      noUrl: 'Aucune URL de redirection fournie',
+      goHome: "Aller à l'accueil",
+      languageBtn: 'English'
+    }
+  };
+
+  const t = isEnglish ? content.en : content.fr;
+
+  return (
+    <>
+      {/* Top App Bar */}
+      <header className="top-app-bar">
+        <div className="top-app-bar-container">
+          <div className="logo-wrapper" onClick={() => (window.location.href = '/')}>
+            <img
+              src="https://moddy.app/logo.png"
+              alt="Moddy Logo"
+              className="logo"
+            />
+          </div>
+
+          <div className="header-actions">
+            <md-icon-button onClick={toggleTheme} className="theme-toggle">
+              <span className="material-symbols-outlined">
+                {isDarkMode ? 'light_mode' : 'dark_mode'}
+              </span>
+            </md-icon-button>
+
+            <md-filled-tonal-button
+              className="language-btn"
+              onClick={() => setIsEnglish(!isEnglish)}
+            >
+              <span className="material-symbols-outlined" slot="icon">
+                language
+              </span>
+              {t.languageBtn}
+            </md-filled-tonal-button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="redirect-section">
+        <div className="redirect-container">
+          {redirectUrl ? (
+            <div className="redirect-card">
+              <md-linear-progress indeterminate></md-linear-progress>
+
+              <div className="redirect-content">
+                <span className="material-symbols-outlined redirect-icon">
+                  open_in_new
+                </span>
+
+                <h1 className="redirect-title md-typescale-headline-medium">
+                  {t.title}
+                </h1>
+
+                <p className="redirect-message md-typescale-body-large">
+                  {t.message} <strong>{countdown}</strong> {t.seconds}
+                </p>
+
+                <div className="redirect-url">
+                  <span className="material-symbols-outlined">link</span>
+                  <span className="redirect-url-text">{redirectUrl}</span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="redirect-card">
+              <div className="redirect-content">
+                <span className="material-symbols-outlined redirect-icon error">
+                  error
+                </span>
+
+                <h1 className="redirect-title md-typescale-headline-medium">
+                  {t.noUrl}
+                </h1>
+
+                <md-filled-button href="/" className="redirect-home-btn">
+                  <span className="material-symbols-outlined" slot="icon">home</span>
+                  {t.goHome}
+                </md-filled-button>
+              </div>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="footer">
+        <div className="footer-container">
+          <p className="footer-text md-typescale-body-small">
+            {isEnglish
+              ? '© 2025 Moddy. All rights reserved. Developed by'
+              : '© 2025 Moddy. Tous droits réservés. Développé par'}{' '}
+            <a
+              href="https://juthing.xyz"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="footer-link"
+            >
+              @juthing
+            </a>
+          </p>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/app/redirect/redirect-styles.css
+++ b/app/redirect/redirect-styles.css
@@ -1,0 +1,145 @@
+/* Redirect Page Styles - Material Design 3 */
+
+/* === Main Section === */
+.redirect-section {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 96px 16px 48px;
+  background: var(--md-sys-color-background);
+}
+
+.redirect-container {
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* === Redirect Card === */
+.redirect-card {
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-extra-large);
+  overflow: hidden;
+  box-shadow: var(--md-sys-elevation-level1);
+}
+
+.redirect-card md-linear-progress {
+  width: 100%;
+  --md-linear-progress-active-indicator-color: var(--md-sys-color-primary);
+  --md-linear-progress-track-color: var(--md-sys-color-surface-container-high);
+  --md-linear-progress-active-indicator-height: 4px;
+  --md-linear-progress-track-height: 4px;
+}
+
+.redirect-content {
+  padding: 48px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+/* === Icon === */
+.redirect-icon {
+  font-size: 48px;
+  color: var(--md-sys-color-primary);
+  margin-bottom: 8px;
+}
+
+.redirect-icon.error {
+  color: var(--md-sys-color-error);
+}
+
+/* === Typography === */
+.redirect-title {
+  color: var(--md-sys-color-on-surface);
+  margin: 0;
+}
+
+.redirect-message {
+  color: var(--md-sys-color-on-surface-variant);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.redirect-message strong {
+  color: var(--md-sys-color-primary);
+  font-size: 24px;
+  font-weight: 500;
+}
+
+/* === URL Display === */
+.redirect-url {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--md-sys-color-surface-container-high);
+  border-radius: var(--md-sys-shape-corner-medium);
+  margin-top: 8px;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.redirect-url .material-symbols-outlined {
+  font-size: 20px;
+  color: var(--md-sys-color-on-surface-variant);
+  flex-shrink: 0;
+}
+
+.redirect-url-text {
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 14px;
+  font-family: 'Roboto Mono', monospace;
+  word-break: break-all;
+}
+
+/* === Home Button === */
+.redirect-home-btn {
+  margin-top: 8px;
+}
+
+/* === Responsive Design === */
+@media (max-width: 768px) {
+  .redirect-section {
+    padding: 80px 16px 32px;
+  }
+
+  .redirect-content {
+    padding: 40px 32px;
+  }
+
+  .redirect-title {
+    font-size: 24px !important;
+    line-height: 32px !important;
+  }
+
+  .redirect-message {
+    font-size: 14px !important;
+  }
+
+  .redirect-icon {
+    font-size: 40px;
+  }
+}
+
+@media (max-width: 480px) {
+  .redirect-content {
+    padding: 32px 24px;
+  }
+
+  .redirect-title {
+    font-size: 20px !important;
+    line-height: 28px !important;
+  }
+
+  .redirect-icon {
+    font-size: 36px;
+  }
+
+  .redirect-message strong {
+    font-size: 20px;
+  }
+}

--- a/app/theme.css
+++ b/app/theme.css
@@ -1,11 +1,11 @@
 /* Material Design 3 Theme - Modern & Clean */
 
 :root {
-  /* === Primary Color - Deep Purple === */
-  --md-sys-color-primary: rgb(103, 80, 164);
+  /* === Primary Color - Blue === */
+  --md-sys-color-primary: rgb(25, 118, 210);
   --md-sys-color-on-primary: rgb(255, 255, 255);
-  --md-sys-color-primary-container: rgb(234, 221, 255);
-  --md-sys-color-on-primary-container: rgb(33, 0, 94);
+  --md-sys-color-primary-container: rgb(210, 227, 252);
+  --md-sys-color-on-primary-container: rgb(0, 29, 53);
 
   /* === Secondary Color - Teal === */
   --md-sys-color-secondary: rgb(98, 91, 113);
@@ -14,10 +14,10 @@
   --md-sys-color-on-secondary-container: rgb(30, 25, 43);
 
   /* === Tertiary Color - Accent === */
-  --md-sys-color-tertiary: rgb(125, 82, 96);
+  --md-sys-color-tertiary: rgb(0, 131, 143);
   --md-sys-color-on-tertiary: rgb(255, 255, 255);
-  --md-sys-color-tertiary-container: rgb(255, 217, 227);
-  --md-sys-color-on-tertiary-container: rgb(55, 11, 30);
+  --md-sys-color-tertiary-container: rgb(188, 235, 241);
+  --md-sys-color-on-tertiary-container: rgb(0, 31, 35);
 
   /* === Error === */
   --md-sys-color-error: rgb(186, 26, 26);
@@ -159,6 +159,60 @@
   --md-sys-motion-duration-long2: 500ms;
   --md-sys-motion-duration-long3: 550ms;
   --md-sys-motion-duration-long4: 600ms;
+}
+
+/* === Dark Theme === */
+[data-theme="dark"] {
+  /* === Primary Color - Blue (Dark) === */
+  --md-sys-color-primary: rgb(166, 200, 245);
+  --md-sys-color-on-primary: rgb(0, 49, 95);
+  --md-sys-color-primary-container: rgb(0, 71, 134);
+  --md-sys-color-on-primary-container: rgb(210, 227, 252);
+
+  /* === Secondary Color (Dark) === */
+  --md-sys-color-secondary: rgb(204, 194, 220);
+  --md-sys-color-on-secondary: rgb(51, 44, 64);
+  --md-sys-color-secondary-container: rgb(74, 68, 88);
+  --md-sys-color-on-secondary-container: rgb(232, 222, 248);
+
+  /* === Tertiary Color - Accent (Dark) === */
+  --md-sys-color-tertiary: rgb(140, 219, 230);
+  --md-sys-color-on-tertiary: rgb(0, 54, 61);
+  --md-sys-color-tertiary-container: rgb(0, 77, 87);
+  --md-sys-color-on-tertiary-container: rgb(188, 235, 241);
+
+  /* === Error (Dark) === */
+  --md-sys-color-error: rgb(255, 180, 171);
+  --md-sys-color-on-error: rgb(105, 0, 5);
+  --md-sys-color-error-container: rgb(147, 0, 10);
+  --md-sys-color-on-error-container: rgb(255, 218, 214);
+
+  /* === Neutral & Surface (Dark) === */
+  --md-sys-color-background: rgb(20, 18, 24);
+  --md-sys-color-on-background: rgb(230, 225, 229);
+  --md-sys-color-surface: rgb(20, 18, 24);
+  --md-sys-color-on-surface: rgb(230, 225, 229);
+  --md-sys-color-surface-variant: rgb(73, 69, 79);
+  --md-sys-color-on-surface-variant: rgb(202, 196, 208);
+
+  /* === Outline (Dark) === */
+  --md-sys-color-outline: rgb(147, 143, 153);
+  --md-sys-color-outline-variant: rgb(73, 69, 79);
+
+  /* === Surface Containers (Dark) === */
+  --md-sys-color-surface-container-lowest: rgb(15, 13, 19);
+  --md-sys-color-surface-container-low: rgb(29, 27, 32);
+  --md-sys-color-surface-container: rgb(33, 31, 38);
+  --md-sys-color-surface-container-high: rgb(43, 41, 48);
+  --md-sys-color-surface-container-highest: rgb(54, 52, 59);
+
+  --md-sys-color-surface-dim: rgb(20, 18, 24);
+  --md-sys-color-surface-bright: rgb(59, 56, 62);
+
+  /* === Inverse (Dark) === */
+  --md-sys-color-inverse-surface: rgb(230, 225, 229);
+  --md-sys-color-inverse-on-surface: rgb(50, 47, 53);
+  --md-sys-color-inverse-primary: rgb(25, 118, 210);
 }
 
 /* === Material Web Components Customization === */


### PR DESCRIPTION
… typography

- Change primary theme color from purple to blue
- Add complete dark theme color tokens
- Implement dark/light mode toggle in header with localStorage persistence
- Create redirect page with progress indicator and 3-second countdown
- Increase homepage text sizes for better readability (64px title, 32px subtitle, 18px body)
- Improve spacing throughout homepage (larger gaps, padding, and margins)
- Enhance feature cards with larger icons and better hover states
- Add subtle pulse animation to status badge indicator
- Update responsive breakpoints to accommodate larger text sizes