### PR TITLE
Fix Material Design 3 implementation with proper colors and styles

### DIFF
--- a/app/forms/mK9qPA/form-styles.css
+++ b/app/forms/mK9qPA/form-styles.css
@@ -80,20 +80,16 @@
   flex-wrap: wrap;
 }
 
-.form-badges md-assist-chip {
-  --md-assist-chip-outline-width: 0px;
-}
-
-/* Badge Official - Fond bleu pastel */
+/* Badge Official - Blue outlined */
 .form-badges md-assist-chip.badge-official {
-  --md-assist-chip-container-color: rgb(227, 242, 253);
-  --md-assist-chip-label-text-color: rgb(1, 87, 155);
+  --md-assist-chip-outline-color: rgb(25, 118, 210);
+  --md-assist-chip-label-text-color: rgb(25, 118, 210);
 }
 
-/* Badge Open - Fond vert pastel */
+/* Badge Open - Green outlined */
 .form-badges md-assist-chip.badge-open {
-  --md-assist-chip-container-color: rgb(232, 245, 233);
-  --md-assist-chip-label-text-color: rgb(27, 94, 32);
+  --md-assist-chip-outline-color: rgb(46, 125, 50);
+  --md-assist-chip-label-text-color: rgb(46, 125, 50);
 }
 
 /* === Typography === */

--- a/app/forms/mK9qPA/page.js
+++ b/app/forms/mK9qPA/page.js
@@ -74,7 +74,7 @@ export default function FormPage() {
         <div className="form-top-app-bar-container">
           <div className="form-logo-wrapper" onClick={() => (window.location.href = '/')}>
             <img
-              src="https://moddy.app/logo.png"
+              src={isDarkMode ? "https://www.moddy.app/logowhite.png" : "https://moddy.app/logo.png"}
               alt="Moddy Logo"
               className="form-logo"
             />

--- a/app/globals.css
+++ b/app/globals.css
@@ -136,15 +136,15 @@ body {
   margin-top: 0;
   font-size: 64px !important;
   line-height: 72px !important;
-  font-weight: 400;
+  font-weight: 700;
   letter-spacing: -0.5px;
 }
 
 .hero-subtitle {
   color: var(--md-sys-color-on-surface-variant);
   margin-top: 0;
-  font-size: 32px !important;
-  line-height: 40px !important;
+  font-size: 18px !important;
+  line-height: 28px !important;
   font-weight: 400;
 }
 
@@ -266,11 +266,12 @@ body {
   .hero-title {
     font-size: 44px !important;
     line-height: 52px !important;
+    font-weight: 700;
   }
 
   .hero-subtitle {
-    font-size: 26px !important;
-    line-height: 34px !important;
+    font-size: 16px !important;
+    line-height: 26px !important;
   }
 
   .hero-description {
@@ -311,11 +312,12 @@ body {
   .hero-title {
     font-size: 36px !important;
     line-height: 44px !important;
+    font-weight: 700;
   }
 
   .hero-subtitle {
-    font-size: 22px !important;
-    line-height: 30px !important;
+    font-size: 15px !important;
+    line-height: 24px !important;
   }
 
   .hero-description {

--- a/app/page.js
+++ b/app/page.js
@@ -58,7 +58,7 @@ export default function Home() {
         <div className="top-app-bar-container">
           <div className="logo-wrapper" onClick={() => (window.location.href = '/')}>
             <img
-              src="https://moddy.app/logo.png"
+              src={isDarkMode ? "https://www.moddy.app/logowhite.png" : "https://moddy.app/logo.png"}
               alt="Moddy Logo"
               className="logo"
             />

--- a/app/redirect/page.js
+++ b/app/redirect/page.js
@@ -10,7 +10,6 @@ import './redirect-styles.css';
 export default function RedirectPage() {
   const [isEnglish, setIsEnglish] = useState(true);
   const [isDarkMode, setIsDarkMode] = useState(false);
-  const [countdown, setCountdown] = useState(3);
   const [redirectUrl, setRedirectUrl] = useState('');
 
   // Initialize theme from localStorage
@@ -31,22 +30,15 @@ export default function RedirectPage() {
     }
   }, []);
 
-  // Countdown and redirect
+  // Redirect after 3 seconds
   useEffect(() => {
     if (!redirectUrl) return;
 
-    const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          window.location.href = redirectUrl;
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
+    const timer = setTimeout(() => {
+      window.location.href = redirectUrl;
+    }, 3000);
 
-    return () => clearInterval(timer);
+    return () => clearTimeout(timer);
   }, [redirectUrl]);
 
   const toggleTheme = () => {
@@ -60,16 +52,14 @@ export default function RedirectPage() {
   const content = {
     en: {
       title: 'Redirecting...',
-      message: 'You will be redirected in',
-      seconds: 'seconds',
+      message: 'You will be redirected shortly',
       noUrl: 'No redirect URL provided',
       goHome: 'Go to Home',
       languageBtn: 'Français'
     },
     fr: {
       title: 'Redirection...',
-      message: 'Vous serez redirigé dans',
-      seconds: 'secondes',
+      message: 'Vous allez être redirigé',
       noUrl: 'Aucune URL de redirection fournie',
       goHome: "Aller à l'accueil",
       languageBtn: 'English'
@@ -85,7 +75,7 @@ export default function RedirectPage() {
         <div className="top-app-bar-container">
           <div className="logo-wrapper" onClick={() => (window.location.href = '/')}>
             <img
-              src="https://moddy.app/logo.png"
+              src={isDarkMode ? "https://www.moddy.app/logowhite.png" : "https://moddy.app/logo.png"}
               alt="Moddy Logo"
               className="logo"
             />
@@ -128,7 +118,7 @@ export default function RedirectPage() {
                 </h1>
 
                 <p className="redirect-message md-typescale-body-large">
-                  {t.message} <strong>{countdown}</strong> {t.seconds}
+                  {t.message}
                 </p>
 
                 <div className="redirect-url">

--- a/app/redirect/redirect-styles.css
+++ b/app/redirect/redirect-styles.css
@@ -21,7 +21,6 @@
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-extra-large);
   overflow: hidden;
-  box-shadow: var(--md-sys-elevation-level1);
 }
 
 .redirect-card md-linear-progress {
@@ -62,12 +61,6 @@
   color: var(--md-sys-color-on-surface-variant);
   margin: 0;
   line-height: 1.5;
-}
-
-.redirect-message strong {
-  color: var(--md-sys-color-primary);
-  font-size: 24px;
-  font-weight: 500;
 }
 
 /* === URL Display === */
@@ -137,9 +130,5 @@
 
   .redirect-icon {
     font-size: 36px;
-  }
-
-  .redirect-message strong {
-    font-size: 20px;
   }
 }

--- a/app/theme.css
+++ b/app/theme.css
@@ -7,11 +7,11 @@
   --md-sys-color-primary-container: rgb(210, 227, 252);
   --md-sys-color-on-primary-container: rgb(0, 29, 53);
 
-  /* === Secondary Color - Teal === */
-  --md-sys-color-secondary: rgb(98, 91, 113);
+  /* === Secondary Color === */
+  --md-sys-color-secondary: rgb(84, 110, 122);
   --md-sys-color-on-secondary: rgb(255, 255, 255);
-  --md-sys-color-secondary-container: rgb(232, 222, 248);
-  --md-sys-color-on-secondary-container: rgb(30, 25, 43);
+  --md-sys-color-secondary-container: rgb(216, 227, 233);
+  --md-sys-color-on-secondary-container: rgb(16, 31, 36);
 
   /* === Tertiary Color - Accent === */
   --md-sys-color-tertiary: rgb(0, 131, 143);
@@ -26,31 +26,31 @@
   --md-sys-color-on-error-container: rgb(65, 0, 2);
 
   /* === Neutral & Surface === */
-  --md-sys-color-background: rgb(254, 247, 255);
-  --md-sys-color-on-background: rgb(29, 27, 32);
-  --md-sys-color-surface: rgb(254, 247, 255);
-  --md-sys-color-on-surface: rgb(29, 27, 32);
-  --md-sys-color-surface-variant: rgb(231, 224, 236);
-  --md-sys-color-on-surface-variant: rgb(73, 69, 79);
+  --md-sys-color-background: rgb(250, 249, 253);
+  --md-sys-color-on-background: rgb(26, 28, 30);
+  --md-sys-color-surface: rgb(250, 249, 253);
+  --md-sys-color-on-surface: rgb(26, 28, 30);
+  --md-sys-color-surface-variant: rgb(224, 226, 230);
+  --md-sys-color-on-surface-variant: rgb(68, 71, 75);
 
   /* === Outline === */
-  --md-sys-color-outline: rgb(121, 116, 126);
-  --md-sys-color-outline-variant: rgb(202, 196, 208);
+  --md-sys-color-outline: rgb(116, 119, 123);
+  --md-sys-color-outline-variant: rgb(196, 199, 203);
 
   /* === Surface Containers === */
   --md-sys-color-surface-container-lowest: rgb(255, 255, 255);
-  --md-sys-color-surface-container-low: rgb(247, 242, 250);
-  --md-sys-color-surface-container: rgb(243, 237, 247);
-  --md-sys-color-surface-container-high: rgb(236, 230, 240);
-  --md-sys-color-surface-container-highest: rgb(230, 224, 233);
+  --md-sys-color-surface-container-low: rgb(244, 243, 247);
+  --md-sys-color-surface-container: rgb(238, 238, 242);
+  --md-sys-color-surface-container-high: rgb(232, 232, 236);
+  --md-sys-color-surface-container-highest: rgb(227, 227, 230);
 
-  --md-sys-color-surface-dim: rgb(222, 216, 225);
-  --md-sys-color-surface-bright: rgb(254, 247, 255);
+  --md-sys-color-surface-dim: rgb(218, 217, 221);
+  --md-sys-color-surface-bright: rgb(250, 249, 253);
 
   /* === Inverse === */
-  --md-sys-color-inverse-surface: rgb(50, 47, 53);
-  --md-sys-color-inverse-on-surface: rgb(245, 239, 247);
-  --md-sys-color-inverse-primary: rgb(208, 188, 255);
+  --md-sys-color-inverse-surface: rgb(47, 48, 51);
+  --md-sys-color-inverse-on-surface: rgb(241, 240, 244);
+  --md-sys-color-inverse-primary: rgb(166, 200, 245);
 
   /* === Typography - Material Design 3 === */
   --md-sys-typescale-display-large-font: 'Roboto Flex', 'Roboto', system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
- Change form badges to outlined style with colored borders (blue for Official, green for Open)
- Remove countdown from redirect page and simplify design
- Fix theme colors: replace purple/violet tones with neutral blue-grey colors
- Update background, surface, and container colors to Material Design blue theme
- Add white logo support for dark mode across all pages
- Make homepage title bold (font-weight: 700)
- Unify subtitle and description text sizes (both 18px)
- Remove unnecessary box shadows from redirect page
- Update all responsive breakpoints to maintain consistent styling