### PR TITLE
Improve sign-in page and user menu UX

### DIFF
--- a/site/site/css/sign-in-page.css
+++ b/site/site/css/sign-in-page.css
@@ -8,126 +8,13 @@
  * Styles for the sign-in page
  */
 
-.sign-in-container {
+.sign-in-loading {
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: calc(100vh - var(--catalog-top-app-bar-height));
-  padding: var(--catalog-spacing-xl);
 }
 
-.sign-in-card {
-  background-color: var(--md-sys-color-surface-container-low);
-  border-radius: var(--catalog-shape-xl);
-  border: 1px solid var(--md-sys-color-outline-variant);
-  padding: var(--catalog-spacing-xl);
-  max-width: 500px;
-  width: 100%;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-}
-
-.sign-in-header {
-  text-align: center;
-  margin-bottom: var(--catalog-spacing-xl);
-}
-
-.sign-in-header h1 {
-  font-size: var(--catalog-display-m-font-size);
-  margin: 0 0 var(--catalog-spacing-m) 0;
-  color: var(--md-sys-color-on-surface);
-}
-
-.sign-in-header .subtitle {
-  font-size: var(--catalog-body-l-font-size);
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0;
-}
-
-.sign-in-content {
-  margin-bottom: var(--catalog-spacing-xl);
-}
-
-.loading-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--catalog-spacing-l);
-  padding: var(--catalog-spacing-xl) 0;
-}
-
-.loading-state md-circular-progress {
+.sign-in-loading md-circular-progress {
   --md-circular-progress-size: 48px;
-}
-
-.loading-state p {
-  font-size: var(--catalog-body-l-font-size);
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0;
-}
-
-.error-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--catalog-spacing-m);
-  padding: var(--catalog-spacing-xl) 0;
-  text-align: center;
-}
-
-.error-state .error-icon {
-  font-size: 48px;
-  color: var(--md-sys-color-error);
-  width: 48px;
-  height: 48px;
-}
-
-.error-state h3 {
-  font-size: var(--catalog-title-l-font-size);
-  color: var(--md-sys-color-error);
-  margin: 0;
-}
-
-.error-state p {
-  font-size: var(--catalog-body-m-font-size);
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0;
-}
-
-.error-state md-filled-button {
-  margin-top: var(--catalog-spacing-m);
-}
-
-.sign-in-footer {
-  text-align: center;
-  padding-top: var(--catalog-spacing-l);
-  border-top: 1px solid var(--md-sys-color-outline-variant);
-}
-
-.sign-in-footer p {
-  font-size: var(--catalog-body-m-font-size);
-  color: var(--md-sys-color-on-surface-variant);
-  margin: 0;
-}
-
-.sign-in-footer a {
-  color: var(--md-sys-color-primary);
-  text-decoration: none;
-}
-
-.sign-in-footer a:hover {
-  text-decoration: underline;
-}
-
-@media screen and (max-width: 600px) {
-  .sign-in-container {
-    padding: var(--catalog-spacing-m);
-  }
-
-  .sign-in-card {
-    padding: var(--catalog-spacing-l);
-  }
-
-  .sign-in-header h1 {
-    font-size: var(--catalog-title-l-font-size);
-  }
 }

--- a/site/site/sign-in/index.html
+++ b/site/site/sign-in/index.html
@@ -1,7 +1,6 @@
 ---
 name: Sign In
 title: Sign In with Discord
-order: 1
 ---
 
 {% extends 'default.html' %}
@@ -13,37 +12,8 @@ order: 1
 
 {% block content %}
 
-<div class="sign-in-container">
-  <div class="sign-in-card">
-    <div class="sign-in-header">
-      <h1>Welcome to Moddy App</h1>
-      <p class="subtitle">Sign in with your Discord account to get started</p>
-    </div>
-
-    <div class="sign-in-content">
-      <div id="loading-state" class="loading-state">
-        <md-circular-progress indeterminate></md-circular-progress>
-        <p>Connecting to Discord...</p>
-      </div>
-
-      <div id="error-state" class="error-state" style="display: none;">
-        <md-icon class="error-icon">error</md-icon>
-        <h3>Authentication Error</h3>
-        <p id="error-message">An error occurred during authentication.</p>
-        <md-filled-button id="retry-button">
-          Try Again
-        </md-filled-button>
-      </div>
-    </div>
-
-    <div class="sign-in-footer">
-      <p>
-        By signing in, you agree to our
-        <a href="/legal/terms-of-service/">Terms of Service</a> and
-        <a href="/legal/privacy-policy/">Privacy Policy</a>.
-      </p>
-    </div>
-  </div>
+<div class="sign-in-loading">
+  <md-circular-progress indeterminate></md-circular-progress>
 </div>
 
 {% endblock %}

--- a/site/site/sign-in/sign-in.json
+++ b/site/site/sign-in/sign-in.json
@@ -1,5 +1,5 @@
 {
   "layout": "layouts/docs.html",
-  "tags": "auth",
-  "hasToc": false
+  "hasToc": false,
+  "eleventyExcludeFromCollections": true
 }

--- a/site/src/components/top-app-bar.ts
+++ b/site/src/components/top-app-bar.ts
@@ -63,15 +63,18 @@ export class TopAppBar extends SignalElement(LitElement) {
   }
 
   /**
-   * Handle logout
+   * Handle dashboard navigation
    */
-  private async handleLogout() {
-    const success = await logout();
-    if (success) {
-      this.isAuthenticated = false;
-      this.userInfo = null;
-      window.location.href = '/';
-    }
+  private handleDashboard() {
+    window.location.href = 'https://dashboard.moddy.app';
+  }
+
+  /**
+   * Handle sign out
+   */
+  private handleSignOut() {
+    const currentUrl = encodeURIComponent(window.location.href);
+    window.location.href = `https://api.moddy.app/auth/logout?url=${currentUrl}`;
   }
 
   render() {
@@ -148,14 +151,25 @@ export class TopAppBar extends SignalElement(LitElement) {
             menu-corner="end-start"
             anchor-corner="end-end"
             default-focus="none">
-            <md-menu-item disabled>
-              <div slot="headline">${this.userInfo.username}</div>
-              <div slot="supporting-text">${this.userInfo.email || 'No email'}</div>
-            </md-menu-item>
-            <md-menu-item @click=${this.handleLogout}>
-              <md-icon slot="start">logout</md-icon>
-              <div slot="headline">Logout</div>
-            </md-menu-item>
+            <div class="user-menu-content">
+              <div class="user-menu-header">
+                ${this.userInfo.avatar_url
+                  ? html`<img
+                      src="${this.userInfo.avatar_url}"
+                      alt="${this.userInfo.username}"
+                      class="user-menu-avatar" />`
+                  : html`<md-icon class="user-menu-avatar-icon">account_circle</md-icon>`}
+                <div class="user-menu-greeting">Hello @${this.userInfo.username}!</div>
+              </div>
+              <div class="user-menu-actions">
+                <md-filled-button @click=${this.handleDashboard}>
+                  Dashboard
+                </md-filled-button>
+                <md-filled-tonal-button @click=${this.handleSignOut}>
+                  Sign out
+                </md-filled-tonal-button>
+              </div>
+            </div>
           </md-menu>
         </div>
       `;
@@ -268,6 +282,52 @@ export class TopAppBar extends SignalElement(LitElement) {
 
     #user-menu-button {
       --md-icon-button-icon-size: 32px;
+    }
+
+    .user-menu-content {
+      padding: var(--catalog-spacing-l);
+      min-width: 280px;
+    }
+
+    .user-menu-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--catalog-spacing-m);
+      padding-bottom: var(--catalog-spacing-l);
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
+    }
+
+    .user-menu-avatar {
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+
+    .user-menu-avatar-icon {
+      font-size: 64px;
+      width: 64px;
+      height: 64px;
+      color: var(--md-sys-color-primary);
+    }
+
+    .user-menu-greeting {
+      font-size: var(--catalog-body-l-font-size);
+      font-weight: 700;
+      color: var(--md-sys-color-on-surface);
+      text-align: center;
+    }
+
+    .user-menu-actions {
+      display: flex;
+      gap: var(--catalog-spacing-s);
+      padding-top: var(--catalog-spacing-l);
+    }
+
+    .user-menu-actions md-filled-button,
+    .user-menu-actions md-filled-tonal-button {
+      flex: 1;
     }
 
     #menu-island {

--- a/site/src/pages/sign-in.ts
+++ b/site/src/pages/sign-in.ts
@@ -14,25 +14,6 @@ import { signInWithDiscord, verifySession } from '../utils/auth.js';
  * Initialize the sign-in page
  */
 async function initSignIn() {
-  const loadingState = document.getElementById('loading-state');
-  const errorState = document.getElementById('error-state');
-  const errorMessage = document.getElementById('error-message');
-  const retryButton = document.getElementById('retry-button');
-
-  // Show error function
-  const showError = (message: string) => {
-    if (loadingState) loadingState.style.display = 'none';
-    if (errorState) errorState.style.display = 'flex';
-    if (errorMessage) errorMessage.textContent = message;
-  };
-
-  // Retry button handler
-  if (retryButton) {
-    retryButton.addEventListener('click', () => {
-      window.location.reload();
-    });
-  }
-
   try {
     // First, check if user is already authenticated
     const session = await verifySession();
@@ -47,11 +28,8 @@ async function initSignIn() {
     await signInWithDiscord();
   } catch (error) {
     console.error('Sign-in error:', error);
-    showError(
-      error instanceof Error
-        ? error.message
-        : 'An unexpected error occurred. Please try again.'
-    );
+    // On error, just redirect to home
+    window.location.href = '/';
   }
 }
 


### PR DESCRIPTION
Sign-in page improvements:
- Hide sign-in page from navigation menu (eleventyExcludeFromCollections)
- Simplify to show only a loading spinner during authentication
- Cleaner, minimal design with automatic redirect

User menu improvements (Google-style):
- Show large avatar (64px) at top center
- Display "Hello @username!" greeting in bold
- Add Dashboard button (links to dashboard.moddy.app)
- Add Sign out button (links to api.moddy.app/auth/logout?url=...)
- Professional card layout with proper spacing
- Two-button layout side by side

These changes create a more polished authentication experience.