### PR TITLE
Move footer outside main container to bottom of page

### DIFF
--- a/site/site/_includes/default.html
+++ b/site/site/_includes/default.html
@@ -67,11 +67,11 @@
         <main id="main-content" slot="app-content" tabindex="0">
           <!-- this is the content of the page -->
           {% block content %}{{ content | safe }}{% endblock %}
-
-          <footer class="page-footer">
-            <p>© 2025 Moddy. All rights reserved. Developed by <a href="https://github.com/juthing/" target="_blank">@<strong>juthing</strong></a> • <a href="https://docs.moddy.app/legal/privacy">Privacy Policy</a> • <a href="https://docs.moddy.app/legal/tos">Terms of Service</a></p>
-          </footer>
         </main>
+
+        <footer class="page-footer" slot="app-content">
+          <p>© 2025 Moddy. All rights reserved. Developed by <a href="https://github.com/juthing/" target="_blank">@<strong>juthing</strong></a> • <a href="https://docs.moddy.app/legal/privacy">Privacy Policy</a> • <a href="https://docs.moddy.app/legal/tos">Terms of Service</a></p>
+        </footer>
         <md-list
             aria-label="List of pages"
             role="menubar"

--- a/site/site/css/global.css
+++ b/site/site/css/global.css
@@ -215,17 +215,17 @@ nav-drawer .drawer-actions md-icon svg {
 
 /* Page footer */
 .page-footer {
-  margin-top: var(--catalog-spacing-xl);
-  padding-top: var(--catalog-spacing-l);
-  border-top: 1px solid var(--md-sys-color-outline-variant);
+  margin-top: calc(var(--catalog-spacing-xl) * 3);
+  padding: var(--catalog-spacing-l) var(--catalog-spacing-m);
   text-align: center;
+  background-color: transparent;
 }
 
 .page-footer p {
   font-size: 12px;
   color: var(--md-sys-color-on-surface-variant);
   margin: 0;
-  opacity: 0.7;
+  opacity: 0.6;
 }
 
 .page-footer a {
@@ -235,4 +235,5 @@ nav-drawer .drawer-actions md-icon svg {
 
 .page-footer a:hover {
   text-decoration: underline;
+  opacity: 1;
 }


### PR DESCRIPTION
- Move footer element outside <main> tag
- Add slot='app-content' to footer for proper positioning
- Increase top margin significantly for visual separation
- Remove border-top, use transparent background
- Footer now appears below the white content container