### PR TITLE
Update Discord OAuth URL configuration

### DIFF
--- a/site/site/_includes/default.html
+++ b/site/site/_includes/default.html
@@ -93,7 +93,7 @@
           <!-- Redirections section -->
           <md-item><div slot="headline">Redirections</div></md-item>
           <md-list-item
-            href="https://discord.com/oauth2/authorize?client_id=1373916203814490194"
+            href="https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fapi.moddy.app%2Fauth%2Fdiscord%2Fcallback&scope=identify+email+connections+role_connections.write"
             role="menuitem"
             type="link"
             target="_blank"

--- a/site/site/index.html
+++ b/site/site/index.html
@@ -364,7 +364,7 @@ hasToc: false
         Your all-in-one Discord bot solution for server management, moderation, and community engagement.
       </p>
       <div class="hero-actions">
-        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194" target="_blank">
+        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fapi.moddy.app%2Fauth%2Fdiscord%2Fcallback&scope=identify+email+connections+role_connections.write" target="_blank">
           Add to Discord
         </md-filled-button>
         <md-outlined-button href="https://dashboard.moddy.app" target="_blank">
@@ -505,7 +505,7 @@ hasToc: false
         Start free. Upgrade when you're ready. Cancel anytime (but you won't want to).
       </p>
       <div class="cta-actions">
-        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194" target="_blank">
+        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fapi.moddy.app%2Fauth%2Fdiscord%2Fcallback&scope=identify+email+connections+role_connections.write" target="_blank">
           Add Moddy to Discord
         </md-filled-button>
       </div>

--- a/site/src/utils/config.ts
+++ b/site/src/utils/config.ts
@@ -24,4 +24,4 @@ export const API_KEY = import.meta.env.A_API_KEY || '';
 // Discord OAuth Configuration
 export const DISCORD_CLIENT_ID = '1373916203814490194';
 export const DISCORD_REDIRECT_URI = `${API_URL}/auth/discord/callback`;
-export const DISCORD_SCOPES = 'identify email';
+export const DISCORD_SCOPES = 'identify email connections role_connections.write';


### PR DESCRIPTION
Add connections and role_connections.write scopes to Discord OAuth URLs. This update applies to:
- config.ts: Updated DISCORD_SCOPES constant
- index.html: Updated 2 "Add to Discord" button URLs
- default.html: Updated navigation "Add moddy" link

The new OAuth URL includes:
- response_type=code
- redirect_uri=https://api.moddy.app/auth/discord/callback
- scope=identify email connections role_connections.write