### PR TITLE
Redesign 404 page with minimalist Material Design style

### DIFF
--- a/site/site/404.html
+++ b/site/site/404.html
@@ -12,40 +12,153 @@ permalink: 404.html
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-height: 60vh;
+    min-height: 65vh;
     text-align: center;
     padding: var(--catalog-spacing-xl);
+    gap: 0;
+  }
+
+  .error-illustration {
+    position: relative;
+    margin-bottom: var(--catalog-spacing-l);
+    user-select: none;
   }
 
   .error-code {
-    font-size: 140px;
+    font-size: 160px;
     font-weight: 700;
     -webkit-font-smoothing: antialiased;
     color: var(--md-sys-color-primary);
     line-height: 1;
-    margin-bottom: var(--catalog-spacing-m);
+    letter-spacing: -4px;
+    opacity: 0.12;
   }
 
-  .error-message {
-    font-size: var(--catalog-title-l-font-size);
+  .error-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 64px;
+    color: var(--md-sys-color-primary);
+    font-variation-settings: 'FILL' 0, 'wght' 300, 'GRAD' 0, 'opsz' 48;
+    animation: error-float 3s ease-in-out infinite;
+  }
+
+  .error-title {
+    font-size: var(--catalog-display-m-font-size);
+    font-weight: 600;
+    -webkit-font-smoothing: antialiased;
+    color: var(--md-sys-color-on-surface);
+    margin: 0 0 var(--catalog-spacing-s) 0;
+    line-height: 1.2;
+  }
+
+  .error-subtitle {
+    font-size: var(--catalog-body-l-font-size);
     color: var(--md-sys-color-on-surface-variant);
-    margin-bottom: var(--catalog-spacing-xl);
+    margin: 0 0 var(--catalog-spacing-xl) 0;
+    max-width: 400px;
+    line-height: 1.5;
+  }
+
+  .error-actions {
+    display: flex;
+    gap: var(--catalog-spacing-m);
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .error-actions md-filled-button {
+    --md-filled-button-container-height: 48px;
+    --md-filled-button-label-text-size: var(--catalog-body-l-font-size);
+  }
+
+  .error-actions md-outlined-button {
+    --md-outlined-button-container-height: 48px;
+    --md-outlined-button-label-text-size: var(--catalog-body-l-font-size);
+  }
+
+  .error-hint {
+    margin-top: calc(var(--catalog-spacing-xl) * 1.5);
+    padding: var(--catalog-spacing-l) var(--catalog-spacing-xl);
+    background-color: var(--md-sys-color-surface-container-low);
+    border-radius: var(--catalog-shape-xl);
+    border: 1px solid var(--md-sys-color-outline-variant);
+    font-size: var(--catalog-body-m-font-size);
+    color: var(--md-sys-color-on-surface-variant);
+    display: flex;
+    align-items: center;
+    gap: var(--catalog-spacing-s);
+  }
+
+  .error-hint .hint-icon {
+    font-size: 20px;
+    color: var(--md-sys-color-on-surface-variant);
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 20;
+    flex-shrink: 0;
+  }
+
+  @keyframes error-float {
+    0%, 100% { transform: translate(-50%, -50%); }
+    50% { transform: translate(-50%, calc(-50% - 8px)); }
   }
 
   @media screen and (max-width: 600px) {
     .error-code {
-      font-size: 100px;
+      font-size: 120px;
+    }
+
+    .error-icon {
+      font-size: 48px;
+    }
+
+    .error-title {
+      font-size: var(--catalog-title-l-font-size);
+    }
+
+    .error-actions {
+      flex-direction: column;
+      width: 100%;
+    }
+
+    .error-actions md-filled-button,
+    .error-actions md-outlined-button {
+      width: 100%;
+    }
+
+    .error-hint {
+      text-align: left;
     }
   }
 </style>
 
 <lit-island on:visible import="/js/hydration-entrypoints/form-controls.js">
   <div class="error-page">
-    <div class="error-code">404</div>
-    <p class="error-message">Page not found</p>
-    <md-filled-button href="/">
-      <span class="material-symbols-outlined" slot="icon">home</span>
-      Back to Home
-    </md-filled-button>
+    <div class="error-illustration">
+      <div class="error-code">404</div>
+      <span class="material-symbols-outlined error-icon">explore_off</span>
+    </div>
+
+    <h1 class="error-title">Well, this is awkward.</h1>
+    <p class="error-subtitle">
+      The page you're looking for doesn't exist, got moved, or is just hiding from you.
+    </p>
+
+    <div class="error-actions">
+      <md-filled-button href="/">
+        <span class="material-symbols-outlined" slot="icon">home</span>
+        Back to Home
+      </md-filled-button>
+      <md-outlined-button href="/support/">
+        <span class="material-symbols-outlined" slot="icon">support_agent</span>
+        Get Help
+      </md-outlined-button>
+    </div>
+
+    <div class="error-hint">
+      <span class="material-symbols-outlined hint-icon">lightbulb</span>
+      <span>Pro tip: if you typed the URL manually, double-check for typos.</span>
+    </div>
   </div>
 </lit-island>


### PR DESCRIPTION
- Large faded 404 with floating explore_off icon overlay
- Witty but professional copy
- Two action buttons: Back to Home + Get Help
- Subtle hint card with lightbulb icon
- Gentle float animation on the icon
- Fully responsive

https://claude.ai/code/session_01GQgdKbXtTKFztUkHztbfTF