### PR TITLE
Add redirect URL support to sign-in flow

### DIFF
--- a/site/src/pages/sign-in.ts
+++ b/site/src/pages/sign-in.ts
@@ -16,17 +16,22 @@ import { signInWithDiscord, verifySession } from '../utils/auth.js';
  */
 async function initSignIn() {
   try {
+    // Extract redirect URL from query parameter if present
+    const params = new URLSearchParams(window.location.search);
+    const redirectUrl = params.get('url');
+
     // First, check if user is already authenticated
     const session = await verifySession();
 
     if (session.valid) {
-      // User is already authenticated, redirect to home
-      window.location.href = '/';
+      // User is already authenticated, redirect to specified URL or home
+      window.location.href = redirectUrl || '/';
       return;
     }
 
     // User is not authenticated, start Discord OAuth flow
-    await signInWithDiscord();
+    // Pass the redirect URL to be stored in the OAuth state
+    await signInWithDiscord(redirectUrl || undefined);
   } catch (error) {
     console.error('Sign-in error:', error);
     // On error, just redirect to home


### PR DESCRIPTION
## Summary
Enhanced the sign-in page to support redirecting users to a specified URL after authentication, rather than always redirecting to the home page.

## Key Changes
- Extract `url` query parameter from the sign-in page URL to determine the post-authentication redirect destination
- Pass the redirect URL to the `signInWithDiscord()` function so it can be preserved through the OAuth flow
- Updated redirect logic to use the specified URL if provided, otherwise fall back to the home page (`/`)
- Added clarifying comments explaining the redirect behavior

## Implementation Details
- Uses `URLSearchParams` to parse the query string and extract the `url` parameter
- The redirect URL is passed to `signInWithDiscord()` as an optional parameter (undefined if not provided)
- Maintains backward compatibility by defaulting to `/` when no redirect URL is specified
- Works for both authenticated users (immediate redirect) and unauthenticated users (redirect after OAuth completion)

https://claude.ai/code/session_01JHepuJHqsfmH3zy5xPxCBq