### PR TITLE
Fix iframe breakout and update stats display

### DIFF
--- a/site/site/_includes/default.html
+++ b/site/site/_includes/default.html
@@ -290,6 +290,21 @@
     </style>
 
     <script>
+      // Prevent pages from being loaded inside iframes (e.g., from status page)
+      // This fixes the issue where clicking the logo in the Instatus iframe
+      // loads the homepage inside the iframe instead of redirecting the parent page
+      (function() {
+        if (window.self !== window.top) {
+          try {
+            window.top.location.href = window.location.href;
+          } catch (e) {
+            // Cross-origin iframe - can't redirect parent
+            console.warn('Cannot redirect parent frame due to cross-origin restrictions');
+          }
+        }
+      })();
+
+      // Development status popup
       (function() {
         var popup = document.getElementById('dev-status-popup');
         if (localStorage.getItem('dev-status-dismissed')) {

--- a/site/site/index.html
+++ b/site/site/index.html
@@ -376,11 +376,11 @@ hasToc: false
     <!-- Stats Section -->
     <section class="stats-section">
       <div class="stat-item">
-        <div class="stat-number" data-target="10000" data-suffix="K+">0</div>
+        <div class="stat-number">--</div>
         <div class="stat-label">Active Servers</div>
       </div>
       <div class="stat-item">
-        <div class="stat-number" data-target="500000" data-suffix="K+">0</div>
+        <div class="stat-number">--</div>
         <div class="stat-label">Community Users</div>
       </div>
       <div class="stat-item">


### PR DESCRIPTION
## Summary
This PR addresses two issues: preventing pages from being loaded inside iframes (particularly from status page embeds) and updating the stats section display to use placeholder values instead of animated counters.

## Key Changes
- **Added iframe breakout protection** in the default layout template that redirects the parent window when the site is loaded inside an iframe, with graceful handling for cross-origin restrictions
- **Updated stats display** on the homepage to show `--` as placeholder values instead of animated counter values with data attributes

## Implementation Details
The iframe protection script uses a self-executing function that checks if the current window is the top-level window. If not, it attempts to redirect the parent frame to the current page URL. A try-catch block handles cross-origin iframe scenarios where the redirect would fail, logging a warning instead of throwing an error.

The stats section changes remove the data-driven animation attributes (`data-target` and `data-suffix`) and replace the dynamic counter values with static `--` placeholders, likely pending a future implementation or API integration.

https://claude.ai/code/session_01TJPosHXEb4c3hSs9Zfi5sf