### PR TITLE
Replace NaN with N/A in stats counter

### DIFF
--- a/site/site/index.html
+++ b/site/site/index.html
@@ -527,6 +527,16 @@ hasToc: false
   function animateCounter(element) {
     const target = parseInt(element.dataset.target);
     const suffix = element.dataset.suffix || '';
+
+    // Skip animation if target is not a number (e.g., for "--" placeholders)
+    if (isNaN(target)) {
+      // Replace NaN with N/A if the element shows NaN
+      if (element.textContent === 'NaN' || element.textContent.includes('NaN')) {
+        element.textContent = 'N/A';
+      }
+      return;
+    }
+
     const duration = 1500; // 1.5 seconds
     const frameDuration = 1000 / 60; // 60fps
     const totalFrames = Math.round(duration / frameDuration);


### PR DESCRIPTION
Added validation to the animateCounter function to:
- Skip animation for elements without data-target attribute
- Replace any NaN display with N/A for better UX
- Prevent JavaScript errors when stats don't have numeric values

This ensures that placeholder stats (--) and invalid values display cleanly without showing "NaN" to users.

https://claude.ai/code/session_01TJPosHXEb4c3hSs9Zfi5sf