### PR TITLE
Update Discord OAuth buttons to use simplified authorize URL

### DIFF
--- a/site/site/_includes/default.html
+++ b/site/site/_includes/default.html
@@ -107,7 +107,7 @@
             tabindex="-1"
           >Documentation</md-list-item>
           <md-list-item
-            href="https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fapi.moddy.app%2Fauth%2Fdiscord%2Fcallback&scope=identify+email+connections+role_connections.write"
+            href="https://discord.com/oauth2/authorize?client_id=1373916203814490194"
             role="menuitem"
             type="link"
             target="_blank"

--- a/site/site/index.html
+++ b/site/site/index.html
@@ -364,7 +364,7 @@ hasToc: false
         Your all-in-one Discord bot solution for server management, moderation, and community engagement.
       </p>
       <div class="hero-actions">
-        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fapi.moddy.app%2Fauth%2Fdiscord%2Fcallback&scope=identify+email+connections+role_connections.write" target="_blank">
+        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194" target="_blank">
           Add to Discord
         </md-filled-button>
         <md-outlined-button href="https://dashboard.moddy.app" target="_blank">
@@ -505,7 +505,7 @@ hasToc: false
         Start free. Upgrade when you're ready. Cancel anytime (but you won't want to).
       </p>
       <div class="cta-actions">
-        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194&response_type=code&redirect_uri=https%3A%2F%2Fapi.moddy.app%2Fauth%2Fdiscord%2Fcallback&scope=identify+email+connections+role_connections.write" target="_blank">
+        <md-filled-button href="https://discord.com/oauth2/authorize?client_id=1373916203814490194" target="_blank">
           Add Moddy to Discord
         </md-filled-button>
       </div>


### PR DESCRIPTION
Replace the full OAuth2 flow URL (with redirect_uri, scopes, response_type) with the base authorize URL for all three Add to Discord buttons:
- Hero section button (index.html)
- CTA section button (index.html)
- Sidebar navigation link (default.html)

https://claude.ai/code/session_01Qek71rBCNpfjmJW8zKijSM