### PR TITLE
Add redirect pages for privacy policy and terms of service

### DIFF
--- a/site/site/privacy/index.html
+++ b/site/site/privacy/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/legal/privacy/" />
+    <title>Redirecting to Privacy Policy...</title>
+    <meta name="theme-color" content="#251f16" />
+    <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
+
+    {% inlinejs "inline/apply-saved-theme.js" %}
+
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html, body {
+        width: 100%;
+        height: 100%;
+        font-family: 'Google Sans', Roboto, system-ui;
+        background-color: var(--md-sys-color-surface-container);
+      }
+
+      .redirect-loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      .spinner {
+        width: 48px;
+        height: 48px;
+        border: 4px solid var(--md-sys-color-surface-container-highest);
+        border-top-color: var(--md-sys-color-primary);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to { transform: rotate(360deg); }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="redirect-loading">
+      <div class="spinner"></div>
+    </div>
+    <script>
+      window.location.href = "https://docs.moddy.app/legal/privacy/";
+    </script>
+  </body>
+</html>

--- a/site/site/terms/index.html
+++ b/site/site/terms/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/legal/tos/" />
+    <title>Redirecting to Terms of Service...</title>
+    <meta name="theme-color" content="#251f16" />
+    <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
+
+    {% inlinejs "inline/apply-saved-theme.js" %}
+
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html, body {
+        width: 100%;
+        height: 100%;
+        font-family: 'Google Sans', Roboto, system-ui;
+        background-color: var(--md-sys-color-surface-container);
+      }
+
+      .redirect-loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      .spinner {
+        width: 48px;
+        height: 48px;
+        border: 4px solid var(--md-sys-color-surface-container-highest);
+        border-top-color: var(--md-sys-color-primary);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to { transform: rotate(360deg); }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="redirect-loading">
+      <div class="spinner"></div>
+    </div>
+    <script>
+      window.location.href = "https://docs.moddy.app/legal/tos/";
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds redirect pages for the privacy policy and terms of service that forward users to the centralized legal documentation hosted on docs.moddy.app.

## Key Changes
- Added `site/site/privacy/index.html` - Redirect page that forwards users to https://docs.moddy.app/legal/privacy/
- Added `site/site/terms/index.html` - Redirect page that forwards users to https://docs.moddy.app/legal/tos/

## Implementation Details
Both redirect pages follow an identical pattern:
- Use `<meta http-equiv="refresh">` for server-side redirect fallback
- Include a JavaScript redirect as the primary mechanism
- Display a loading spinner while the redirect occurs
- Maintain consistent styling with the existing site theme using CSS variables
- Include proper meta tags for viewport, charset, and theme color
- Reference the site's favicon and theme application script

https://claude.ai/code/session_01XiXTEocCpNezzivnyZAzWK