### PR TITLE
Update CTA section heading with placeholder text

### DIFF
--- a/site/site/index.html
+++ b/site/site/index.html
@@ -500,7 +500,7 @@ hasToc: false
 
     <!-- CTA Section -->
     <section class="cta-section">
-      <h2>Join the 10,000+ servers that already get it</h2>
+      <h2>Join the -- servers that already get it</h2>
       <p>
         Start free. Upgrade when you're ready. Cancel anytime (but you won't want to).
       </p>


### PR DESCRIPTION
## Summary
Updated the call-to-action section heading on the homepage to use placeholder text instead of a specific server count metric.

## Changes
- Modified the CTA section heading from "Join the 10,000+ servers that already get it" to "Join the -- servers that already get it"
- This appears to be a temporary placeholder, likely pending updated statistics or a decision on how to present user/server metrics

## Notes
The double dash (`--`) suggests this is a work-in-progress change. Consider whether this should be replaced with:
- An updated server count
- A dynamic value pulled from analytics
- Alternative messaging that doesn't rely on a specific metric

https://claude.ai/code/session_01PnFcZGgT7apcAUwNJV1dHD