### PR TITLE
Simplify top app bar branding text from "Moddy App" to "Moddy"

### DIFF
--- a/site/src/components/top-app-bar.ts
+++ b/site/src/components/top-app-bar.ts
@@ -117,7 +117,7 @@ export class TopAppBar extends SignalElement(LitElement) {
           </section>
 
           <a href="/" id="home-link">
-            Moddy App
+            Moddy
             <md-focus-ring for="home-link"></md-focus-ring>
           </a>
 


### PR DESCRIPTION
## Summary
Updated the top app bar branding text to use a shorter, more concise label.

## Changes
- Changed the home link text in the top app bar from "Moddy App" to "Moddy"

## Details
This is a minor branding/UI text update that simplifies the application name displayed in the top navigation bar while maintaining the same link functionality and focus ring behavior.

https://claude.ai/code/session_01FHvbg5LHmxezc2jgrFn2fr