### PR TITLE
Add redirect URL support to Discord OAuth sign-in flow

### DIFF
--- a/site/src/pages/sign-in.ts
+++ b/site/src/pages/sign-in.ts
@@ -30,7 +30,7 @@ async function initSignIn() {
     }
 
     // Not logged in — redirect to backend Discord OAuth
-    signInWithDiscord();
+    signInWithDiscord(redirectUrl ?? undefined);
   } catch (error) {
     console.error('Sign-in error:', error);
     window.location.href = '/';

--- a/site/src/utils/auth.ts
+++ b/site/src/utils/auth.ts
@@ -80,8 +80,10 @@ export async function getMe(): Promise<User | null> {
  * Redirects the browser to the backend Discord OAuth login.
  * The backend handles the full OAuth flow and sets the session cookie.
  */
-export function signInWithDiscord(): void {
-  window.location.href = `${API_URL}/auth/login`;
+export function signInWithDiscord(redirectUrl?: string): void {
+  const url = new URL(`${API_URL}/auth/login`);
+  if (redirectUrl) url.searchParams.set('redirect', redirectUrl);
+  window.location.href = url.toString();
 }
 
 /**


### PR DESCRIPTION
## Summary
Enhanced the Discord OAuth sign-in flow to support optional redirect URLs, allowing users to be redirected to a specific page after successful authentication instead of always returning to the default location.

## Key Changes
- Modified `signInWithDiscord()` function to accept an optional `redirectUrl` parameter
- Updated the function to construct a URL with query parameters instead of a simple string concatenation
- Added logic to append the `redirect` query parameter to the OAuth login endpoint when a redirect URL is provided
- Updated the sign-in page to pass the `redirectUrl` to the `signInWithDiscord()` function

## Implementation Details
- The redirect URL is passed as a query parameter (`redirect`) to the backend OAuth endpoint
- The parameter is optional and only included in the request when explicitly provided
- Uses the `URL` and `URLSearchParams` APIs for proper URL construction and parameter handling

https://claude.ai/code/session_0139qRCvvVHDiqzUzhbyzbYi