### PR TITLE
Add site-wide banner system and redirect lookup functionality

### DIFF
--- a/site/site/404.html
+++ b/site/site/404.html
@@ -6,6 +6,20 @@ hasToc: false
 permalink: 404.html
 ---
 
+<script>
+(function() {
+  var path = window.location.pathname;
+  fetch('https://api.moddy.app/redirects/lookup?domain=moddy.app&path=' + encodeURIComponent(path))
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data && typeof data.path === 'string' && data.path) {
+        window.location.replace(data.path);
+      }
+    })
+    .catch(function() {});
+})();
+</script>
+
 <style>
   .error-container {
     display: flex;

--- a/site/site/_includes/default.html
+++ b/site/site/_includes/default.html
@@ -65,6 +65,7 @@
         {% endif %}
 
         <main id="main-content" slot="app-content" tabindex="0">
+          {% include "partials/site-banner.html" %}
           <!-- this is the content of the page -->
           {% block content %}{{ content | safe }}{% endblock %}
         </main>

--- a/site/site/_includes/layouts/fullpage.html
+++ b/site/site/_includes/layouts/fullpage.html
@@ -99,6 +99,8 @@
         });
       </script>
 
+      {% include "partials/site-banner.html" %}
+
       <main class="fullpage-content" id="main-content" tabindex="0">
         {% block content %}{{ content | safe }}{% endblock %}
       </main>

--- a/site/site/_includes/partials/site-banner.html
+++ b/site/site/_includes/partials/site-banner.html
@@ -1,0 +1,129 @@
+<div id="site-banner" style="display:none;" role="alert" aria-live="polite"></div>
+
+<style>
+  #site-banner {
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  #site-banner-message {
+    flex: 1;
+  }
+
+  #site-banner-message a {
+    color: inherit;
+    font-weight: 600;
+  }
+
+  #site-banner-message strong {
+    font-weight: 700;
+  }
+
+  #site-banner-message code {
+    font-family: monospace;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.12);
+  }
+
+  .site-banner-type-icon {
+    font-size: 20px;
+    font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 20;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+
+  .site-banner-custom-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .site-banner-custom-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+</style>
+
+<script>
+(function() {
+  var API_URL = 'https://api.moddy.app';
+  var banner = document.getElementById('site-banner');
+
+  var TYPE_CFG = {
+    announcement: { icon: 'campaign',      bg: 'var(--md-sys-color-secondary-container)', fg: 'var(--md-sys-color-on-secondary-container)' },
+    incident:     { icon: 'error',         bg: 'var(--md-sys-color-error-container)',      fg: 'var(--md-sys-color-on-error-container)' },
+    maintenance:  { icon: 'construction',  bg: 'var(--md-sys-color-tertiary-container)',   fg: 'var(--md-sys-color-on-tertiary-container)' },
+    information:  { icon: 'info',          bg: 'var(--md-sys-color-primary-container)',    fg: 'var(--md-sys-color-on-primary-container)' },
+    warning:      { icon: 'warning',       bg: 'var(--md-sys-color-error-container)',      fg: 'var(--md-sys-color-on-error-container)' },
+    resolved:     { icon: 'check_circle',  bg: 'var(--md-sys-color-secondary-container)', fg: 'var(--md-sys-color-on-secondary-container)' }
+  };
+
+  function md(text) {
+    return text
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/`(.+?)`/g, '<code>$1</code>')
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+  }
+
+  function render(data) {
+    if (!data || !data.show_website) {
+      banner.style.display = 'none';
+      return;
+    }
+
+    // Reset state
+    banner.style.borderLeft = '';
+    banner.innerHTML = '';
+
+    var iconEl = document.createElement('span');
+    var messageEl = document.createElement('div');
+    messageEl.id = 'site-banner-message';
+    messageEl.className = 'site-banner-message';
+
+    if (data.type) {
+      var cfg = TYPE_CFG[data.type] || TYPE_CFG.information;
+      banner.style.backgroundColor = cfg.bg;
+      banner.style.color = cfg.fg;
+      iconEl.className = 'material-symbols-outlined site-banner-type-icon';
+      iconEl.setAttribute('aria-hidden', 'true');
+      iconEl.textContent = cfg.icon;
+    } else {
+      var accent = data.color || 'var(--md-sys-color-primary)';
+      banner.style.backgroundColor = 'var(--md-sys-color-surface-container)';
+      banner.style.color = 'var(--md-sys-color-on-surface)';
+      banner.style.borderLeft = '4px solid ' + accent;
+      if (data.icon_svg) {
+        iconEl.className = 'site-banner-custom-icon';
+        iconEl.style.color = accent;
+        iconEl.setAttribute('aria-hidden', 'true');
+        iconEl.innerHTML = data.icon_svg;
+      }
+    }
+
+    messageEl.innerHTML = md(data.message || '');
+
+    if (iconEl.textContent || iconEl.innerHTML) {
+      banner.appendChild(iconEl);
+    }
+    banner.appendChild(messageEl);
+    banner.style.display = 'flex';
+  }
+
+  function fetchBanner() {
+    fetch(API_URL + '/banners/active')
+      .then(function(r) { return r.json(); })
+      .then(render)
+      .catch(function() {});
+  }
+
+  fetchBanner();
+  setInterval(fetchBanner, 60000);
+})();
+</script>


### PR DESCRIPTION
## Summary
This PR introduces a dynamic site-wide banner system that fetches and displays notifications from a remote API, along with a redirect lookup feature for handling moved content.

## Key Changes

- **New site banner component** (`site-banner.html`):
  - Fetches active banners from `https://api.moddy.app/banners/active` every 60 seconds
  - Supports multiple banner types (announcement, incident, maintenance, information, warning, resolved) with type-specific icons and colors
  - Supports custom banners with custom icons and accent colors
  - Implements markdown-like formatting for message content (bold, italic, code, links)
  - Includes proper accessibility attributes (role="alert", aria-live="polite")
  - Integrated into both default and fullpage layouts

- **Redirect lookup on 404 pages**:
  - Added script to `404.html` that queries `https://api.moddy.app/redirects/lookup` with the current path
  - Automatically redirects users to the correct path if a redirect mapping exists
  - Gracefully handles API failures without breaking the 404 page

- **Layout integration**:
  - Included banner partial in `_includes/layouts/fullpage.html`
  - Included banner partial in `_includes/default.html`

## Implementation Details

- The banner uses CSS custom properties (Material Design 3 color system) for theming
- Type-based banners use Material Symbols icons with specific background/foreground color pairs
- Custom banners support SVG icons and custom accent colors with a left border accent
- All external API calls include error handling to prevent page breakage
- Banner updates are polled every 60 seconds to keep content fresh

https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN