### PR TITLE
feat: banner position + bouton de fermeture

### DIFF
--- a/site/site/_includes/default.html
+++ b/site/site/_includes/default.html
@@ -53,6 +53,7 @@
   <body dsd-pending>
     <!-- Inlines the declarative shadow dom polyfill for FF since it's performance sensitive -->
     {% inlinejs "ssr-utils/dsd-polyfill.js" %}
+    {% include "partials/site-banner.html" %}
     <!-- Changed from on:idle to on:visible for instant navigation load and prevent FOUC -->
     <lit-island on:visible import="/js/hydration-entrypoints/navigation.js">
       <nav-drawer page-title="{{name}}" {% if hasToc %}has-toc{% endif %}>
@@ -65,7 +66,6 @@
         {% endif %}
 
         <main id="main-content" slot="app-content" tabindex="0">
-          {% include "partials/site-banner.html" %}
           <!-- this is the content of the page -->
           {% block content %}{{ content | safe }}{% endblock %}
         </main>

--- a/site/site/_includes/layouts/fullpage.html
+++ b/site/site/_includes/layouts/fullpage.html
@@ -77,6 +77,7 @@
   </head>
   <body dsd-pending>
     {% inlinejs "ssr-utils/dsd-polyfill.js" %}
+    {% include "partials/site-banner.html" %}
     <div class="fullpage-layout">
       <div class="fullpage-topbar">
         <lit-island on:visible import="/js/hydration-entrypoints/navigation.js">
@@ -98,8 +99,6 @@
           }
         });
       </script>
-
-      {% include "partials/site-banner.html" %}
 
       <main class="fullpage-content" id="main-content" tabindex="0">
         {% block content %}{{ content | safe }}{% endblock %}

--- a/site/site/_includes/partials/site-banner.html
+++ b/site/site/_includes/partials/site-banner.html
@@ -2,11 +2,15 @@
 
 <style>
   #site-banner {
+    width: 100%;
+    box-sizing: border-box;
     align-items: center;
+    justify-content: center;
     gap: 10px;
     padding: 10px 16px;
     font-size: 14px;
     line-height: 1.5;
+    text-align: center;
     -webkit-font-smoothing: antialiased;
   }
 

--- a/site/site/_includes/partials/site-banner.html
+++ b/site/site/_includes/partials/site-banner.html
@@ -2,12 +2,13 @@
 
 <style>
   #site-banner {
+    position: relative;
     width: 100%;
     box-sizing: border-box;
     align-items: center;
     justify-content: center;
     gap: 10px;
-    padding: 10px 16px;
+    padding: 10px 40px 10px 16px;
     font-size: 14px;
     line-height: 1.5;
     text-align: center;
@@ -51,6 +52,34 @@
     width: 20px;
     height: 20px;
   }
+
+  #site-banner-close {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    opacity: 0.7;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  #site-banner-close:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  #site-banner-close .material-symbols-outlined {
+    font-size: 18px;
+  }
 </style>
 
 <script>
@@ -78,6 +107,11 @@
 
   function render(data) {
     if (!data || !data.show_website) {
+      banner.style.display = 'none';
+      return;
+    }
+
+    if (sessionStorage.getItem('site-banner-dismissed') === String(data.id)) {
       banner.style.display = 'none';
       return;
     }
@@ -113,10 +147,24 @@
 
     messageEl.innerHTML = md(data.message || '');
 
+    var closeBtn = document.createElement('button');
+    closeBtn.id = 'site-banner-close';
+    closeBtn.setAttribute('aria-label', 'Fermer le bandeau');
+    var closeIcon = document.createElement('span');
+    closeIcon.className = 'material-symbols-outlined';
+    closeIcon.setAttribute('aria-hidden', 'true');
+    closeIcon.textContent = 'close';
+    closeBtn.appendChild(closeIcon);
+    closeBtn.addEventListener('click', function() {
+      sessionStorage.setItem('site-banner-dismissed', String(data.id));
+      banner.style.display = 'none';
+    });
+
     if (iconEl.textContent || iconEl.innerHTML) {
       banner.appendChild(iconEl);
     }
     banner.appendChild(messageEl);
+    banner.appendChild(closeBtn);
     banner.style.display = 'flex';
   }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Changements

Complète le travail de la PR #44 (squash merge incomplet) :

- **Position** : le bandeau est déplacé tout en haut du `<body>`, avant tout wrapper de layout, dans `default.html` et `fullpage.html` — pleine largeur, contenu centré
- **Bouton ×** : croix positionnée absolument à droite du bandeau ; la fermeture est mémorisée en `sessionStorage` par ID de bannière (réapparaît si une nouvelle bannière est publiée)

## Test

- Vérifier que le bandeau s'affiche bien au-dessus de la top-app-bar
- Cliquer la croix → bandeau masqué pour la session
- Changer l'ID de la bannière côté API → bandeau réapparaît

https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN)_