### PR TITLE
feat: bandeau d'information — sticky, icône groupée, bouton ×

### DIFF
--- a/site/site/_includes/partials/site-banner.html
+++ b/site/site/_includes/partials/site-banner.html
@@ -6,19 +6,17 @@
   }
 
   #site-banner {
-    position: fixed;
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
     z-index: 13; /* above top-app-bar (z-index: 12) */
+    width: 100%;
     box-sizing: border-box;
     align-items: center;
     justify-content: center;
     gap: 10px;
-    padding: 10px 40px 10px 16px;
+    padding: 10px 40px;
     font-size: 14px;
     line-height: 1.5;
-    text-align: center;
     -webkit-font-smoothing: antialiased;
   }
 
@@ -27,17 +25,13 @@
     top: var(--site-banner-height) !important;
   }
 
-  /* Push the fullpage layout (sticky topbar + content) below the banner */
-  .fullpage-layout {
-    padding-top: var(--site-banner-height);
-  }
-
+  /* Push the fullpage sticky topbar below the banner */
   .fullpage-topbar {
     top: var(--site-banner-height);
   }
 
   #site-banner-message {
-    flex: 1;
+    text-align: center;
   }
 
   #site-banner-message a {


### PR DESCRIPTION
## Changements

Un seul commit propre sur `site-banner.html` :

- **Position** : `sticky top:0 z-index:13` — dans le flux de la page, le bandeau pousse le contenu vers le bas sans se superposer
- **Top-app-bar** : décalée via `top: var(--site-banner-height)` pour rester sous le bandeau ; `--catalog-top-app-bar-height` ajustée dynamiquement en JS pour que le contenu du nav-drawer parte du bon offset
- **Icône groupée** : suppression de `flex:1` sur le message → l'icône reste collée au texte, le tout centré ensemble
- **Bouton ×** : `position:absolute` à droite, dismiss mémorisé en `sessionStorage` par ID de bannière
- **Markdown** sur le message, icônes Material par type, rendu SVG+couleur personnalisé si `type === null`

https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN)_