### PR TITLE
fix: banner au-dessus de la page sans superposition

### DIFF
--- a/site/site/_includes/partials/site-banner.html
+++ b/site/site/_includes/partials/site-banner.html
@@ -8,7 +8,7 @@
   #site-banner {
     position: sticky;
     top: 0;
-    z-index: 13; /* above top-app-bar (z-index: 12) */
+    z-index: 13;
     width: 100%;
     box-sizing: border-box;
     align-items: center;
@@ -20,12 +20,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  /* Push the fixed top-app-bar below the banner */
-  top-app-bar {
-    top: var(--site-banner-height) !important;
-  }
-
-  /* Push the fullpage sticky topbar below the banner */
+  /* Fullpage layout: push sticky topbar below the banner */
   .fullpage-topbar {
     top: var(--site-banner-height);
   }
@@ -101,7 +96,6 @@
 (function() {
   var API_URL = 'https://api.moddy.app';
   var banner = document.getElementById('site-banner');
-  var _origCatalogH = null;
 
   var TYPE_CFG = {
     announcement: { icon: 'campaign',      bg: 'var(--md-sys-color-secondary-container)', fg: 'var(--md-sys-color-on-secondary-container)' },
@@ -121,47 +115,15 @@
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
   }
 
-  function applyOffset(h) {
-    document.documentElement.style.setProperty('--site-banner-height', h + 'px');
-    // Also shift --catalog-top-app-bar-height so the nav-drawer content
-    // area starts below both the top-app-bar and the banner.
-    if (_origCatalogH === null) {
-      _origCatalogH = parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue('--catalog-top-app-bar-height')
-      ) || 0;
-    }
-    if (_origCatalogH > 0) {
-      document.documentElement.style.setProperty(
-        '--catalog-top-app-bar-height',
-        (_origCatalogH + h) + 'px'
-      );
-    }
-  }
-
-  function clearOffset() {
-    document.documentElement.style.setProperty('--site-banner-height', '0px');
-    if (_origCatalogH !== null && _origCatalogH > 0) {
-      document.documentElement.style.setProperty('--catalog-top-app-bar-height', _origCatalogH + 'px');
-    }
-  }
-
   function hideBanner() {
     banner.style.display = 'none';
-    clearOffset();
+    document.documentElement.style.setProperty('--site-banner-height', '0px');
   }
 
   function render(data) {
-    if (!data || !data.show_website) {
-      hideBanner();
-      return;
-    }
+    if (!data || !data.show_website) { hideBanner(); return; }
+    if (sessionStorage.getItem('site-banner-dismissed') === String(data.id)) { hideBanner(); return; }
 
-    if (sessionStorage.getItem('site-banner-dismissed') === String(data.id)) {
-      hideBanner();
-      return;
-    }
-
-    // Reset state
     banner.style.borderLeft = '';
     banner.innerHTML = '';
 
@@ -205,15 +167,13 @@
       hideBanner();
     });
 
-    if (iconEl.textContent || iconEl.innerHTML) {
-      banner.appendChild(iconEl);
-    }
+    if (iconEl.textContent || iconEl.innerHTML) banner.appendChild(iconEl);
     banner.appendChild(messageEl);
     banner.appendChild(closeBtn);
     banner.style.display = 'flex';
-    // Read height after paint so offsetHeight is accurate
+
     requestAnimationFrame(function() {
-      applyOffset(banner.offsetHeight);
+      document.documentElement.style.setProperty('--site-banner-height', banner.offsetHeight + 'px');
     });
   }
 

--- a/site/src/components/nav-drawer.ts
+++ b/site/src/components/nav-drawer.ts
@@ -265,7 +265,7 @@ export class NavDrawer extends SignalElement(LitElement) {
       /* Removed transition for instant drawer open/close */
       position: fixed;
       isolation: isolate;
-      inset: var(--catalog-top-app-bar-height) 0 0 0;
+      inset: calc(var(--catalog-top-app-bar-height) + var(--site-banner-height, 0px)) 0 0 0;
       z-index: 12;
       background-color: var(--md-sys-color-surface-container);
       overflow: hidden;

--- a/site/src/components/top-app-bar.ts
+++ b/site/src/components/top-app-bar.ts
@@ -207,7 +207,10 @@ export class TopAppBar extends SignalElement(LitElement) {
 
     header {
       position: fixed;
-      inset: 0 0 auto 0;
+      top: var(--site-banner-height, 0px);
+      right: 0;
+      bottom: auto;
+      left: 0;
       display: flex;
       align-items: center;
       box-sizing: border-box;


### PR DESCRIPTION
Un seul commit propre depuis `main`.

## Cause racine

`--catalog-top-app-bar-height` vaut `calc(48px + 2 * var(--catalog-spacing-m))` — le `parseFloat()` retournait `NaN`, donc le décalage du contenu n'était jamais appliqué. Le header bougeait, le contenu non.

## Fix

Modifier les composants directement pour consommer `--site-banner-height` :

- **`top-app-bar.ts`** — `header` part de `top: var(--site-banner-height, 0px)` au lieu de `inset: 0 0 auto 0`
- **`nav-drawer.ts`** — `aside` part de `calc(var(--catalog-top-app-bar-height) + var(--site-banner-height, 0px))` au lieu de `var(--catalog-top-app-bar-height)` seul
- **`site-banner.html`** — `position: sticky`, JS qui ne fait que setter `--site-banner-height` sur `:root` après paint ; les composants se décalent automatiquement en cascade

https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8QRhLzZLSh6d6xTzKCnCN)_