### PR TITLE
fix(404): redirect to data.target instead of data.path

### DIFF
--- a/site/site/404.html
+++ b/site/site/404.html
@@ -12,8 +12,8 @@ permalink: 404.html
   fetch('https://api.moddy.app/redirects/lookup?domain=moddy.app&path=' + encodeURIComponent(path))
     .then(function(r) { return r.json(); })
     .then(function(data) {
-      if (data && typeof data.path === 'string' && data.path) {
-        window.location.replace(data.path);
+      if (data && typeof data.target === 'string' && data.target) {
+        window.location.replace(data.target);
       }
     })
     .catch(function() {});


### PR DESCRIPTION
Fix the redirect logic in the 404 page: was using `data.path` (the source path, causing an infinite loop) — now correctly uses `data.target` (the destination URL).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMRZf5Fch9FwCrNZFRXKDv)_