### PR TITLE
Update legal documentation redirect URLs to new docs structure

### DIFF
--- a/site/site/license/index.html
+++ b/site/site/license/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/fr/legal/license" />
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/legal/license" />
     <title>Redirecting to License...</title>
     <meta name="theme-color" content="#251f16" />
     <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
@@ -51,7 +51,7 @@
       <div class="spinner"></div>
     </div>
     <script>
-      window.location.href = "https://docs.moddy.app/fr/legal/license";
+      window.location.href = "https://docs.moddy.app/legal/license";
     </script>
   </body>
 </html>

--- a/site/site/license/index.html
+++ b/site/site/license/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/fr/legal/tos" />
-    <title>Redirecting to Terms of Service...</title>
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/fr/legal/license" />
+    <title>Redirecting to License...</title>
     <meta name="theme-color" content="#251f16" />
     <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
 
@@ -51,7 +51,7 @@
       <div class="spinner"></div>
     </div>
     <script>
-      window.location.href = "https://docs.moddy.app/fr/legal/tos";
+      window.location.href = "https://docs.moddy.app/fr/legal/license";
     </script>
   </body>
 </html>

--- a/site/site/privacy/index.html
+++ b/site/site/privacy/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/articles/privacy-policy/" />
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/fr/legal/privacy" />
     <title>Redirecting to Privacy Policy...</title>
     <meta name="theme-color" content="#251f16" />
     <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
@@ -51,7 +51,7 @@
       <div class="spinner"></div>
     </div>
     <script>
-      window.location.href = "https://docs.moddy.app/articles/privacy-policy/";
+      window.location.href = "https://docs.moddy.app/fr/legal/privacy";
     </script>
   </body>
 </html>

--- a/site/site/privacy/index.html
+++ b/site/site/privacy/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/fr/legal/privacy" />
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/legal/privacy" />
     <title>Redirecting to Privacy Policy...</title>
     <meta name="theme-color" content="#251f16" />
     <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
@@ -51,7 +51,7 @@
       <div class="spinner"></div>
     </div>
     <script>
-      window.location.href = "https://docs.moddy.app/fr/legal/privacy";
+      window.location.href = "https://docs.moddy.app/legal/privacy";
     </script>
   </body>
 </html>

--- a/site/site/terms/index.html
+++ b/site/site/terms/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/fr/legal/tos" />
+    <meta http-equiv="refresh" content="0; url=https://docs.moddy.app/legal/tos" />
     <title>Redirecting to Terms of Service...</title>
     <meta name="theme-color" content="#251f16" />
     <link href="/images/favicon.svg" rel="icon" sizes="any" type="image/svg+xml">
@@ -51,7 +51,7 @@
       <div class="spinner"></div>
     </div>
     <script>
-      window.location.href = "https://docs.moddy.app/fr/legal/tos";
+      window.location.href = "https://docs.moddy.app/legal/tos";
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Updated redirect pages for legal documentation to point to the new documentation structure under `/legal/` path instead of the previous `/articles/` path.

## Key Changes
- **New license redirect page**: Created `site/site/license/index.html` that redirects to `https://docs.moddy.app/legal/license`
- **Privacy policy redirect**: Updated redirect URL from `https://docs.moddy.app/articles/privacy-policy/` to `https://docs.moddy.app/legal/privacy`
- **Terms of service redirect**: Updated redirect URL from `https://docs.moddy.app/articles/terms-of-service/` to `https://docs.moddy.app/legal/tos`

## Implementation Details
- All redirect pages use both meta refresh tags and JavaScript fallback for robust browser compatibility
- Maintains consistent styling with loading spinner animation across all legal documentation pages
- Follows the existing redirect page pattern with theme color support and responsive viewport configuration

https://claude.ai/code/session_01FPvWnAkUiNpWUQesdHieaz