### PR TITLE
Corrige l'identifiant de service pour la bannière de statut

### DIFF
--- a/site/site/_includes/partials/site-banner.html
+++ b/site/site/_includes/partials/site-banner.html
@@ -96,7 +96,7 @@
 (function() {
   var API_URL = 'https://api.moddy.app';
   var STATUS_API_URL = 'https://health.moddy.app';
-  var STATUS_SERVICE_ID = 'Website';
+  var STATUS_SERVICE_ID = 'moddy-website';
   var banner = document.getElementById('site-banner');
 
   var TYPE_CFG = {


### PR DESCRIPTION
## Summary
- Suite au merge de la [PR #54](https://github.com/moddy-app/Website/pull/54) (intégration de la bannière de statut `health.moddy.app`), l'identifiant de service utilisé pour `?service=` était incorrect.
- Remplace `Website` par `moddy-website`, conforme à la liste officielle des IDs de service (`moddy-bot`, `moddy-api`, `moddy-altguard`, `moddy-feeds`, `moddy-dashboard`, `moddy-website`).

## Test plan
- [ ] Vérifier que la bannière de statut affiche bien un message personnalisé "Website" quand `moddy-website` figure dans les services affectés d'un incident/maintenance de test.


---
_Generated by [Claude Code](https://claude.ai/code/session_0134P4s7UANEnMv5HWzMKWDC)_